### PR TITLE
Remove GraphiQL Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,6 @@ group :development, :test do
 end
 
 group :development do
-  gem 'graphiql-rails'
   gem 'guard-rake'
   gem 'guard-rspec', require: false
   gem 'letter_opener'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,9 +103,6 @@ GEM
       activerecord (>= 4.0.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    graphiql-rails (1.7.0)
-      railties
-      sprockets-rails
     graphql (1.9.3)
     graphql-batch (0.4.0)
       graphql (>= 1.3, < 2)
@@ -348,7 +345,6 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   friendly_id
-  graphiql-rails
   graphql
   graphql-batch
   graphql-errors

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,9 +13,5 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { registrations: 'registrations' }
 
-  if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
-  end
-
   post '/graphql', to: 'graphql#execute'
 end


### PR DESCRIPTION
Removing this because Graphiql is using an endpoint not meant to be public available. 
Use GraphQL Playground instead: https://github.com/prisma/graphql-playground.