### PR TITLE
Redirect user to correct place on welcome controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
       user:               user,
       admin_path:         admin_root_path,
       business_user_path: private_room_root_path,
-      user_path:          root_path
+      user_path:          AppConfig.main_front_page
     ).call
   end
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
 class WelcomeController < ApplicationController
-  def index; end
+  def index
+    redirect_to signed_in_path
+  end
+
+  private
+
+  def signed_in_path
+    AfterSignInPathService.new(
+      user:               current_user,
+      admin_path:         admin_root_path,
+      business_user_path: private_room_root_path,
+      user_path:          AppConfig.main_front_page
+    ).call
+  end
 end

--- a/spec/requests/welcome_spec.rb
+++ b/spec/requests/welcome_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Welcome page', type: :request do
+  before do
+    sign_in(user)
+  end
+
+  context 'when signed in as an admin' do
+    let(:user) { create(:user, :admin) }
+
+    it 'redirects to the admin panel page' do
+      get root_path
+      expect(response).to redirect_to(admin_root_path)
+    end
+  end
+
+  context 'when signed in as a employee' do
+    let(:employee) { create(:employee) }
+    let(:user)     { employee.user }
+
+    it 'redirects to the business panel page' do
+      get root_path
+      expect(response).to redirect_to(private_room_root_path)
+    end
+  end
+
+  context 'when signed in as a regular user' do
+    let(:user) { create(:user) }
+
+    it 'redirects to the main Govinu page' do
+      get root_path
+      expect(response).to redirect_to(AppConfig.main_front_page)
+    end
+  end
+end


### PR DESCRIPTION
When user goes to https://id.govinu.com we should send the user to the correct page (admin, business or customer pages).